### PR TITLE
Version bump to fix throughput bottleneck

### DIFF
--- a/gremlin/pom.xml
+++ b/gremlin/pom.xml
@@ -41,7 +41,7 @@ LICENSE file.
     <dependency>
       <groupId>org.apache.tinkerpop</groupId>
       <artifactId>gremlin-driver</artifactId>
-      <version>3.4.0</version> <!--${gremlin.version}-->
+      <version>3.4.10</version> <!--${gremlin.version}-->
     </dependency>
     <dependency>
       <groupId>site.ycsb</groupId>


### PR DESCRIPTION
Increase gremlin driver to 3.4.10 to address scaling issues in the gremlin driver.
Previous throughput limited to 1700 req/sec.  New driver removes this bottleneck.